### PR TITLE
Don't compile included third party php libraries

### DIFF
--- a/TextformatterOEmbed.module
+++ b/TextformatterOEmbed.module
@@ -1,6 +1,8 @@
 <?php
 
-require_once 'vendor/autoload.php';
+// Don't compile included libraries
+// http://processwire.com/blog/posts/processwire-3.0.43-core-updates/#new-filecompiler-options
+require_once(/*NoCompile*/__DIR__ . '/vendor/autoload.php');
 
 /**
  * ProcessWire Textformatter-oEmbed


### PR DESCRIPTION
Here's a quick fix to prevent Processwire from compiling any third party php files that are included.

http://processwire.com/blog/posts/processwire-3.0.43-core-updates/#new-filecompiler-options

This should be backwards compatible as well since it is just a regular php comment.

Hope that helps